### PR TITLE
wrong IRI template

### DIFF
--- a/mappings/dbpedia.ttl
+++ b/mappings/dbpedia.ttl
@@ -24,7 +24,7 @@
 
 lb:sm_area rr:template "http://musicbrainz.org/area/{gid}#_" .
 lb:sm_artist rr:template "http://musicbrainz.org/artist/{gid}#_" .
-lb:sm_release_group rr:template "http://musicbrainz.org/signal-group/{gid}#_" .
+lb:sm_release_group rr:template "http://musicbrainz.org/release-group/{gid}#_" .
 
 #pt.dbpedia.org wasn't resolving - to check
 


### PR DESCRIPTION
this template creates links like
`http://musicbrainz.org/signal-group/061f572e-7660-3c6b-b4cd-cf66d46da93c#_`
that do not resolve. the proper link should be 
`http://musicbrainz.org/release-group/061f572e-7660-3c6b-b4cd-cf66d46da93c#_`
